### PR TITLE
Fix IntToBaseN implicit conversions

### DIFF
--- a/src/main/scala/BaseN.scala
+++ b/src/main/scala/BaseN.scala
@@ -44,7 +44,7 @@ sealed class BaseN(val underlying: BigInt, val baseN: Int)  {
   def |(that: BaseN) = BaseN(underlying.|(that.underlying), baseN)
   def mod(that:BaseN)= BaseN(underlying.mod(that.underlying),baseN)
   def modInverse(that:BaseN)=BaseN(underlying.modInverse(that.underlying),baseN)
-  def modPow(that:BaseN,p:Int)=BaseN(underlying.modPow(that.underlying,p),baseN)
+  def modPow(that:BaseN,p:BaseN)=BaseN(underlying.modPow(that.underlying,p.underlying),baseN)
   
   def <<(n: Int) = BaseN(underlying.<<(n), baseN)
   def >>(n: Int) = BaseN(underlying.>>(n), baseN)
@@ -83,7 +83,7 @@ object BaseN {
   implicit def BaseNToHDecimal(x: BaseN): Decimal = new Decimal(x.underlying)
   implicit def BaseNToBinary(x: BaseN): BaseN = new Binary(x.underlying)
 
-  implicit def IntToHex(i: Int): Hex = new Hex(BigInt(i)) // to support 0xff etc
+  implicit def IntToBaseN(i: Int): BaseN = new BaseN(BigInt(i), 16) // to support 0xff etc
   implicit def BaseNToInt(n: BaseN): Int = n.toInt
 
   implicit def BigIntToBinary(b: BigInt): Binary = new Binary(b)


### PR DESCRIPTION
- Int is now implicitly converted to BaseN instead of one of its subclass. This preserves polymorphism. (Does not change the behavior of operators as they all return BaseN objects). I chose 16 as a default base for the conversion as it seemed the most used to me (this does not change anything to the behavior of the underlying BigInt).

- modPow switched back to use BaseN as mod.